### PR TITLE
[6.5.x] Set LANG env variable

### DIFF
--- a/kie-drools-wb/src/main/docker/tomcat/Dockerfile
+++ b/kie-drools-wb/src/main/docker/tomcat/Dockerfile
@@ -4,6 +4,9 @@ FROM tomcat:7.0.70-jre8
 ####### MAINTAINER ############
 MAINTAINER "Roger Martinez" "romartin@redhat.com"
 
+####### LOCALE ############
+ENV LANG en_US.UTF-8
+
 ####### ENVIRONMENT ############
 ENV JAVA_OPTS -XX:MaxPermSize=256m -Xms256m -Xmx512m
 ENV CATALINA_OPTS -Xmx512M -XX:MaxPermSize=512m -Dbtm.root=$CATALINA_HOME -Dbitronix.tm.configuration=$CATALINA_HOME/conf/btm-config.properties -Djava.security.egd=file:/dev/./urandom

--- a/kie-drools-wb/src/main/docker/wildfly/Dockerfile
+++ b/kie-drools-wb/src/main/docker/wildfly/Dockerfile
@@ -4,6 +4,9 @@ FROM jboss/wildfly:10.0.0.Final
 ####### MAINTAINER ############
 MAINTAINER "Roger Martinez" "romartin@redhat.com"
 
+####### LOCALE ############
+ENV LANG en_US.UTF-8
+
 ####### ENVIRONMENT ############
 ENV JAVA_OPTS -Xms512m -Xmx1024m
 ENV JBOSS_BIND_ADDRESS 0.0.0.0

--- a/kie-server/src/main/docker/tomcat/Dockerfile
+++ b/kie-server/src/main/docker/tomcat/Dockerfile
@@ -4,6 +4,9 @@ FROM tomcat:7.0.70-jre8
 ####### MAINTAINER ############
 MAINTAINER "Roger Martinez" "romartin@redhat.com"
 
+####### LOCALE ############
+ENV LANG en_US.UTF-8
+
 ####### ENVIRONMENT ############
 ENV JAVA_OPTS -XX:MaxPermSize=256m -Xms256m -Xmx512m
 ENV CATALINA_OPTS -Xmx512M -XX:MaxPermSize=512m -Dbtm.root=$CATALINA_HOME -Dbitronix.tm.configuration=$CATALINA_HOME/conf/btm-config.properties -Djava.security.egd=file:/dev/./urandom

--- a/kie-server/src/main/docker/wildfly/Dockerfile
+++ b/kie-server/src/main/docker/wildfly/Dockerfile
@@ -4,6 +4,9 @@ FROM jboss/wildfly:10.0.0.Final
 ####### MAINTAINER ############
 MAINTAINER "Roger Martinez" "romartin@redhat.com"
 
+####### LOCALE ############
+ENV LANG en_US.UTF-8
+
 ####### ENVIRONMENT ############
 ENV JAVA_OPTS -XX:MaxPermSize=256m -Xms256m -Xmx512m
 ENV JBOSS_BIND_ADDRESS 0.0.0.0

--- a/kie-wb/src/main/docker/tomcat/Dockerfile
+++ b/kie-wb/src/main/docker/tomcat/Dockerfile
@@ -4,6 +4,9 @@ FROM tomcat:7.0.70-jre8
 ####### MAINTAINER ############
 MAINTAINER "Roger Martinez" "romartin@redhat.com"
 
+####### LOCALE ############
+ENV LANG en_US.UTF-8
+
 ####### ENVIRONMENT ############
 ENV JAVA_OPTS -Xms512m -Xmx1024m
 ENV CATALINA_OPTS -Xmx512M -XX:MaxPermSize=512m -Dbtm.root=$CATALINA_HOME -Dbitronix.tm.configuration=$CATALINA_HOME/conf/btm-config.properties -Djava.security.egd=file:/dev/./urandom

--- a/kie-wb/src/main/docker/wildfly/Dockerfile
+++ b/kie-wb/src/main/docker/wildfly/Dockerfile
@@ -4,6 +4,9 @@ FROM jboss/wildfly:10.0.0.Final
 ####### MAINTAINER ############
 MAINTAINER "Roger Martinez" "romartin@redhat.com"
 
+####### LOCALE ############
+ENV LANG en_US.UTF-8
+
 ####### ENVIRONMENT ############
 ENV JAVA_OPTS -Xms256m -Xmx1024m
 ENV JBOSS_BIND_ADDRESS 0.0.0.0

--- a/uf-dashbuilder/src/main/docker/eap/Dockerfile
+++ b/uf-dashbuilder/src/main/docker/eap/Dockerfile
@@ -4,6 +4,9 @@ FROM ce-registry.usersys.redhat.com/jboss-eap-6/eap64:1.3
 ####### MAINTAINER ############
 MAINTAINER "Roger Martinez" "romartin@redhat.com"
 
+####### LOCALE ############
+ENV LANG en_US.UTF-8
+
 ####### ENVIRONMENT ############
 ENV JAVA_OPTS -XX:MaxPermSize=256m -Xms256m -Xmx512m
 ENV JBOSS_BIND_ADDRESS 0.0.0.0

--- a/uf-dashbuilder/src/main/docker/tomcat/Dockerfile
+++ b/uf-dashbuilder/src/main/docker/tomcat/Dockerfile
@@ -4,6 +4,9 @@ FROM tomcat:7.0.70-jre8
 ####### MAINTAINER ############
 MAINTAINER "Roger Martinez" "romartin@redhat.com"
 
+####### LOCALE ############
+ENV LANG en_US.UTF-8
+
 ####### ENVIRONMENT ############
 ENV JAVA_OPTS -XX:MaxPermSize=256m -Xms256m -Xmx512m
 ENV CATALINA_OPTS -Xmx512M -XX:MaxPermSize=512m -Dbtm.root=$CATALINA_HOME -Dbitronix.tm.configuration=$CATALINA_HOME/conf/btm-config.properties -Djava.security.egd=file:/dev/./urandom


### PR DESCRIPTION
I noticed that the LANG variable was not set when I added these lines to the `start_kie-wb.sh`:

```
touch /opt/jboss/wildfly/bin/test.txt
echo "=====" >> /opt/jboss/wildfly/bin/test.txt
echo $LANG >> /opt/jboss/wildfly/bin/test.txt
echo $LANGUAGE >> /opt/jboss/wildfly/bin/test.txt
echo "=====" >> /opt/jboss/wildfly/bin/test.txt
```

and I got this:

```
[root@... bin]# more /opt/jboss/wildfly/bin/test.txt
=====


=====
```

It's important to set that variable, because Workbench runs with UTF-8 encoding (see https://issues.jboss.org/browse/RHBRMS-2519).
