### PR TITLE
Change docker.dashbuilder.artifacts.version to use version.org.uberfire.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <docker.daemon.rest.url>unix:///var/run/docker.sock</docker.daemon.rest.url>
     <docker.kie.repository>jboss-kie</docker.kie.repository>
     <docker.kie.artifacts.version>${project.version}</docker.kie.artifacts.version>
-    <docker.dashbuilder.artifacts.version>${version.org.dashbuilder}</docker.dashbuilder.artifacts.version>
+    <docker.dashbuilder.artifacts.version>${version.org.uberfire}</docker.dashbuilder.artifacts.version>
     <timestamp>${maven.build.timestamp}</timestamp>
     <kie.artifacts.deploy.path>${project.build.directory}/kie-artifacts</kie.artifacts.deploy.path>
 


### PR DESCRIPTION
Looks like dashbuilder was moved to uberfire last week kiegroup/droolsjbpm-build-bootstrap/pull/620, causing a masked build error when getting the project version. Upon full inspection it appeared to fail when parsing version.org.dashbuilder since it was removed from the kie-parent.