### PR TITLE
upgraded to next version

### DIFF
--- a/business-central/pom.xml
+++ b/business-central/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.kie.docker</groupId>
         <artifactId>kie-docker-ci-images</artifactId>
-        <version>7.29.0-SNAPSHOT</version>
+        <version>7.30.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>business-central</artifactId>

--- a/kie-artifacts/pom.xml
+++ b/kie-artifacts/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.docker</groupId>
     <artifactId>kie-docker-ci-images</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.30.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-artifacts</artifactId>

--- a/kie-jboss-modules/pom.xml
+++ b/kie-jboss-modules/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.docker</groupId>
     <artifactId>kie-docker-ci-images</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.30.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-jboss-modules</artifactId>

--- a/kie-server/pom.xml
+++ b/kie-server/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.docker</groupId>
     <artifactId>kie-docker-ci-images</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.30.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-server</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-parent</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.30.0-SNAPSHOT</version>
   </parent>
   <groupId>org.kie.docker</groupId>
   <artifactId>kie-docker-ci-images</artifactId>


### PR DESCRIPTION
Changed like usual - but the mvn clean install doesn't work any more since use of Podman.
Get the following error: https://gist.github.com/mbiarnes/7046891aadf2e62c37e9f99e55966d12
  